### PR TITLE
Document where to find future events

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
 # Machine Learning Working Group
+
+You'll find past events minutes in the `minutes` folder.
+
+If you are interested in upcoming events, the public calendar can be found [here](https://erlef.org/wg/machine-learning/calendar).


### PR DESCRIPTION
I really wondered when the next rounds would happen, so googled a bit and found a link which appears to be relevant.